### PR TITLE
rm unneeded application element from SDK manifest

### DIFF
--- a/tradeit-android-sdk/src/main/AndroidManifest.xml
+++ b/tradeit-android-sdk/src/main/AndroidManifest.xml
@@ -1,8 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="it.trade.android.sdk">
     <uses-permission android:name="android.permission.INTERNET" />
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
 </manifest>


### PR DESCRIPTION
This application element is not needed, and if forcing RTL support on downstream apps.  This breaks layouts on apps that weren't expecting it, so it shouldn't be done from an SDK.