### PR TITLE
[#150424652] Fix Android TLS issue for version < 22

### DIFF
--- a/exampleApp/src/main/AndroidManifest.xml
+++ b/exampleApp/src/main/AndroidManifest.xml
@@ -19,7 +19,6 @@
         </activity>
         <activity
             android:name=".WebViewActivity"
-            android:launchMode="singleTask"
             android:parentActivityName=".OauthLinkBrokerActivity" />
         <activity
             android:name=".LinkedBrokersActivity"

--- a/tradeit-android-sdk/build.gradle
+++ b/tradeit-android-sdk/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:multidex:1.0.1'
     compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'it.trade:tradeit-java-api:1.1.5'
+    compile 'it.trade:tradeit-java-api:1.1.6'
     compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
     // Because RxAndroid releases are few and far between, it is recommended you also
     // explicitly depend on RxJava's latest version for bug fixes and new features.

--- a/tradeit-android-sdk/src/main/java/it/trade/android/sdk/model/TradeItApiClientParcelable.java
+++ b/tradeit-android-sdk/src/main/java/it/trade/android/sdk/model/TradeItApiClientParcelable.java
@@ -1,5 +1,6 @@
 package it.trade.android.sdk.model;
 
+import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 
@@ -16,7 +17,7 @@ public class TradeItApiClientParcelable extends TradeItApiClient implements Parc
         this(apiKey, environment, null);
     }
     public TradeItApiClientParcelable(String apiKey, TradeItEnvironment environment, RequestInterceptorParcelable requestInterceptorParcelable) {
-        super(apiKey, environment, requestInterceptorParcelable);
+        super(apiKey, environment, requestInterceptorParcelable, forceTLS12());
         this.requestInterceptorParcelable = requestInterceptorParcelable;
     }
 
@@ -50,7 +51,7 @@ public class TradeItApiClientParcelable extends TradeItApiClient implements Parc
         this.environment = tmpEnvironment == -1 ? null : TradeItEnvironment.values()[tmpEnvironment];
         this.apiKey = in.readString();
         TradeItRequestWithKey.API_KEY = apiKey;
-        this.tradeItApi = this.createTradeItApi(environment, requestInterceptorParcelable);
+        this.tradeItApi = this.createTradeItApi(environment, requestInterceptorParcelable, forceTLS12());
     }
 
     public static final Creator<TradeItApiClientParcelable> CREATOR = new Creator<TradeItApiClientParcelable>() {
@@ -64,4 +65,8 @@ public class TradeItApiClientParcelable extends TradeItApiClient implements Parc
             return new TradeItApiClientParcelable[size];
         }
     };
+
+    private static boolean forceTLS12() {
+        return (Build.VERSION.SDK_INT >= 16 && Build.VERSION.SDK_INT < 22);
+    }
 }


### PR DESCRIPTION
To review and merge after this one to be released: https://github.com/tradingticket/JavaApi/pull/14
For some reason, android supports TLS v1.2 from API 16, but enables it by
default only from API 20. 