### PR TITLE
Ignore userCanDisableMargin when comparing accounts for sync

### DIFF
--- a/tradeit-android-sdk/src/main/java/it/trade/android/sdk/model/TradeItLinkedBrokerAccountParcelable.java
+++ b/tradeit-android-sdk/src/main/java/it/trade/android/sdk/model/TradeItLinkedBrokerAccountParcelable.java
@@ -256,8 +256,6 @@ public class TradeItLinkedBrokerAccountParcelable implements Parcelable {
             return false;
         if (accountNumber != null ? !accountNumber.equals(that.accountNumber) : that.accountNumber != null)
             return false;
-        if (userCanDisableMargin != that.userCanDisableMargin)
-            return false;
         return accountBaseCurrency != null ? accountBaseCurrency.equals(that.accountBaseCurrency) : that.accountBaseCurrency == null;
 
     }


### PR DESCRIPTION
Was causing an error when syncing because manually constructed accounts always had `userCanDisableMargin` set to false but the local cache can have it set to true. In that case, the accounts still should be considered equal so it doesn't delete/recreate the account.