### PR TITLE
bump the maven plugin version to fix dependencies issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,12 @@ buildscript {
     repositories {
         jcenter()
         google()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-rc02'
+        classpath 'com.android.tools.build:gradle:3.2.0-rc03'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'org.codehaus.groovy:groovy-android-gradle-plugin:1.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.2.0.0"

--- a/tradeit-android-sdk/build.gradle
+++ b/tradeit-android-sdk/build.gradle
@@ -14,7 +14,7 @@ ext {
     siteUrl = 'https://github.com/tradingticket/AndroidSDK'
     gitUrl = 'https://github.com/tradingticket/AndroidSDK.git'
 
-    libraryVersion = '1.0.27'
+    libraryVersion = '1.0.28'
 
     developerId = 'tradingticket'
     developerName = 'Trade It'


### PR DESCRIPTION
bump the android maven plugin version to latest, so that release SDK package on `bintray` can have correct dependencies for `JavaApi` etc.